### PR TITLE
Updating fortniteapi.io doc example to use v2

### DIFF
--- a/docs/api examples/fortniteapiio.js
+++ b/docs/api examples/fortniteapiio.js
@@ -9,7 +9,7 @@ const APIKEY = '';
 const fetchCosmetic = async (name, type) => {
   try {
     const cosmetic = await get({
-      url: `https://fortniteapi.io/items/list?name=${encodeURI(name)}&type=${type}`,
+      url: `https://fortniteapi.io/v2/items/list?name=${encodeURI(name)}&type.id=${type}`,
       headers: { Authorization: APIKEY },
       json: true,
     });


### PR DESCRIPTION
Better use the v2 endpoint which is faster to answer and better overall.
Also the paths that don't start with v1/v2 will soon be disabled.