### PR TITLE
Fix Client#getProfile account not found error

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -560,11 +560,13 @@ class Client extends EventEmitter {
     const users = await Promise.all(proms);
 
     return users.map((u) => {
-      if (u.error && u.error.code !== 'errors.com.epicgames.account.account_not_found') throw u.error;
-
+      if (u?.error) {
+        if (u.error.code === 'errors.com.epicgames.account.account_not_found') return undefined;
+        throw u.error;
+      }
       if (Array.isArray(u.response)) return u.response.map((ur) => new User(this, ur));
       return new User(this, u.response);
-    }).flat(1);
+    }).filter(u => !!u).flat(1) as User[];
   }
 
   /**

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -566,7 +566,7 @@ class Client extends EventEmitter {
       }
       if (Array.isArray(u.response)) return u.response.map((ur) => new User(this, ur));
       return new User(this, u.response);
-    }).filter(u => !!u).flat(1) as User[];
+    }).filter((u) => !!u).flat(1) as User[];
   }
 
   /**


### PR DESCRIPTION
`client.getProfile([name1, name2, ...])` (with an array parameter) throws an exception if one of the names can't be looked up. The exception originates in the `User` constructor, because the `errors.com.epicgames.account.account_not_found` error is ignored and `undefined` is passed to the constructor. This change fixes it by omitting the failed lookups from the result array instead of constructing `User`s for them.