### PR TITLE
Sort output lines in generateExports.js

### DIFF
--- a/generateExports.js
+++ b/generateExports.js
@@ -8,6 +8,7 @@ const fs = require('fs').promises;
 
   output += '\n// exceptions\n';
   const exceptions = await fs.readdir('./src/exceptions');
+  exceptions.sort();
   exceptions.forEach((file) => {
     const fileWithoutExtension = file.split('.')[0];
     output += `export { default as ${fileWithoutExtension} } from './src/exceptions/${fileWithoutExtension}';\n`;
@@ -15,6 +16,7 @@ const fs = require('fs').promises;
 
   output += '\n// structures\n';
   const structures = await fs.readdir('./src/structures');
+  structures.sort();
   structures.forEach((file) => {
     const fileWithoutExtension = file.split('.')[0];
     output += `export { default as ${fileWithoutExtension} } from './src/structures/${fileWithoutExtension}';\n`;


### PR DESCRIPTION
Currently, the order of lines emitted by `generateExports.js` depends on the filesystem's sorting. Windows and Linux disagree about whether "SentFriendMessage.ts" sorts before or after "STWHero.ts", so there are a few lines that swap positions when building on a different platform.

This adds an explicit sort step, so the line ordering will be stable across platforms as long as the implementation of `Array#sort` is.