### PR TITLE
Optional Property Access For Some STW Stats.

### DIFF
--- a/src/structures/stw/STWHeroLoadout.ts
+++ b/src/structures/stw/STWHeroLoadout.ts
@@ -63,8 +63,8 @@ class STWHeroLoadout extends STWItem {
     ];
 
     this.gadgets = [
-      data.attributes.gadgets.find((g) => g.slot_index === 0)?.gadget,
-      data.attributes.gadgets.find((g) => g.slot_index === 1)?.gadget,
+      data.attributes.gadgets?.find((g) => g.slot_index === 0)?.gadget,
+      data.attributes.gadgets?.find((g) => g.slot_index === 1)?.gadget,
     ];
   }
 }

--- a/src/structures/stw/STWStats.ts
+++ b/src/structures/stw/STWStats.ts
@@ -145,7 +145,7 @@ class STWStats extends Base {
     }));
 
     this.rewardsClaimedPostMaxLevel = data.rewards_claimed_post_max_level;
-    this.collectionBookMaxXPLevel = data.collection_book.maxBookXpLevelAchieved;
+    this.collectionBookMaxXPLevel = data.collection_book?.maxBookXpLevelAchieved;
     this.mfaRewardClaimed = data.mfa_reward_claimed;
 
     this.quests = data.quest_manager?.questPoolStats ? {
@@ -168,7 +168,7 @@ class STWStats extends Base {
     this.unslotMtxSpend = data.unslot_mtx_spend;
     this.clientSettings = data.client_settings;
 
-    this.researchLevels = typeof data.research_levels.fortitude === 'number' ? {
+    this.researchLevels = typeof data.research_levels?.fortitude === 'number' ? {
       fortitude: data.research_levels.fortitude!,
       resistance: data.research_levels.resistance!,
       technology: data.research_levels.technology!,
@@ -187,7 +187,7 @@ class STWStats extends Base {
       lost: data.xp_lost,
     };
 
-    this.dailyRewards = data.daily_rewards.lastClaimDate ? {
+    this.dailyRewards = data.daily_rewards?.lastClaimDate ? {
       nextDefaultReward: data.daily_rewards.nextDefaultReward!,
       totalDaysLoggedIn: data.daily_rewards.totalDaysLoggedIn!,
       lastClaimDate: new Date(data.daily_rewards.lastClaimDate),


### PR DESCRIPTION
**Reason:** Constantly currently getting errors on some of the 3.0.0 stw functions causing a large amount of false positives in sentry.

**Fix:** Adding optional property access for some attributes to reduce undefined errors in the relevant stw objects where the null check is on the attribute rather than the parent object