### PR TITLE
Use id instead of displayName in join request URL parameter

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -791,7 +791,7 @@ class Client extends EventEmitter {
     try {
       intention = await this.http.epicgamesRequest({
         method: 'POST',
-        url: `${Endpoints.BR_PARTY}/members/${resolvedFriend.id}/intentions/${this.user.self!.displayName}`,
+        url: `${Endpoints.BR_PARTY}/members/${resolvedFriend.id}/intentions/${this.user.self!.id}`,
         headers: {
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
This fixes an "Target accountId ... does not match the authenticated user" error when requesting to join a party.