### PR TITLE
(Docs) Fix authorization code link

### DIFF
--- a/docs/general/auth.md
+++ b/docs/general/auth.md
@@ -28,7 +28,7 @@ const { Client } = require('fnbr');
 ```
 
 ## How do I obtain an authorization code?
-You can use [this link](https://www.epicgames.com/id/logout?redirectUrl=https%3A//www.epicgames.com/id/login%3FredirectUrl%3Dhttps%253A%252F%252Fwww.epicgames.com%252Fid%252Fapi%252Fredirect%253FclientId%253D3446cd72694c4a4485d81b77adbb2141%2526responseType%253Dcode) and copy the 32 character code! An authorization code can only be used once and expires after 300 seconds. Thats why you should generate a device auth with it.
+You can use [this link](https://www.fortnite.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D3446cd72694c4a4485d81b77adbb2141%26responseType%3Dcode) and copy the 32 character code! An authorization code can only be used once and expires after 300 seconds. Thats why you should generate a device auth with it.
 
 ## How does a device auth work?
 A device auth doesn't expire and it consists of a accountId, deviceId and secret. You can create as many device auths for an account as you want.


### PR DESCRIPTION
The authorization code in the documentation is incorrect as it always returns "Incorrect Response. Please refresh the page"
![image](https://github.com/fnbrjs/fnbr.js/assets/57068341/3930e5c8-c198-41cf-95c5-b67748d3eec3)

So I changed 
https://www.epicgames.com/id/logout?redirectUrl=https%3A//www.epicgames.com/id/login%3FredirectUrl%3Dhttps%253A%252F%252Fwww.epicgames.com%252Fid%252Fapi%252Fredirect%253FclientId%253D3446cd72694c4a4485d81b77adbb2141%2526responseType%253Dcode
To
https://www.fortnite.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D3446cd72694c4a4485d81b77adbb2141%26responseType%3Dcode