### PR TITLE
Allow Users with exactly 3 or exactly 16 characters to be found.

### DIFF
--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -82,7 +82,7 @@ class UserManager extends Base {
         } else {
           ids.push(idOrDisplayName);
         }
-      } else if (idOrDisplayName.length > 3 && idOrDisplayName.length < 16) {
+      } else if (idOrDisplayName.length >= 3 && idOrDisplayName.length <= 16) {
         const cachedUser = this.cache.find((u) => u.displayName === idOrDisplayName);
         if (cachedUser) {
           const cachedUserClone = new User(this.client, cachedUser.toObject());


### PR DESCRIPTION
Currently, if a user has a username 3 characters long or exactly 16 they won't pass the length check and will return not found. This adds a greater than and less than comparison operator to prevent this.