### PR TITLE
fix emotes

### DIFF
--- a/resources/defaultPartyMemberMeta.json
+++ b/resources/defaultPartyMemberMeta.json
@@ -14,7 +14,7 @@
   "Default:FortCommonMatchmakingData_j": "{\"FortCommonMatchmakingData\":{\"request\":{\"linkId\":{\"mnemonic\":\"\",\"version\":-1},\"matchmakingTransaction\":\"NotReady\",\"requester\":\"INVALID\",\"version\":0},\"response\":\"NONE\",\"version\":0}}",
   "Default:FortMatchmakingMemberData_j": "{\"FortMatchmakingMemberData\":{\"request\":{\"members\":[{\"player\":\"\",\"readiness\":\"NotReady\",\"currentGameId\":{\"mnemonic\":\"\",\"version\":-1},\"currentGameType\":\"UNDEFINED\",\"currentGameSessionId\":\"\",\"version\":101}],\"requester\":\"\",\"version\":1},\"response\":\"NONE\",\"version\":1}}",
   "Default:FrontEndMapMarker_j": "{\"FrontEndMapMarker\":{\"markerLocation\":{\"x\":0,\"y\":0},\"bIsSet\":false}}",
-  "Default:FrontendEmote_j": "{\"FrontendEmote\":{\"emoteItemDef\":\"None\",\"emoteEKey\":\"\",\"emoteSection\":-1}}",
+  "Default:FrontendEmote_j": "{\"FrontendEmote\":{\"pickable\":\"None\",\"emoteEKey\":\"\",\"emoteSection\":-1}}",
   "Default:JoinInProgressData_j": "{\"JoinInProgressData\":{\"request\":{\"target\":\"INVALID\",\"time\":0},\"responses\":[]}}",
   "Default:JoinMethod_s": "Creation",
   "Default:LobbyState_j": "{\"LobbyState\":{\"inGameReadyCheckStatus\":\"None\",\"gameReadiness\":\"NotReady\",\"readyInputType\":\"Count\",\"currentInputType\":\"MouseAndKeyboard\",\"hiddenMatchmakingDelayMax\":0,\"hasPreloadedAthena\":false}}",

--- a/src/structures/party/ClientPartyMember.ts
+++ b/src/structures/party/ClientPartyMember.ts
@@ -431,14 +431,14 @@ class ClientPartyMember extends PartyMember {
    * @throws {EpicgamesAPIError}
    */
   public async setEmote(id: string, path?: string) {
-    if (this.meta.get('Default:FrontendEmote_j').FrontendEmote.emoteItemDef !== 'None') await this.clearEmote();
+    if (this.meta.get('Default:FrontendEmote_j').FrontendEmote.pickable !== 'None') await this.clearEmote();
 
     let data = this.meta.get('Default:FrontendEmote_j');
     data = this.meta.set('Default:FrontendEmote_j', {
       ...data,
       FrontendEmote: {
         ...data.FrontendEmote,
-        emoteItemDef: `${path?.replace(/\/$/, '') ?? '/BRCosmetics/Athena/Items/Cosmetics/Dances'}/${id}.${id}`,
+        pickable: `${path?.replace(/\/$/, '') ?? '/BRCosmetics/Athena/Items/Cosmetics/Dances'}/${id}.${id}`,
         emoteSection: -2,
       },
     });
@@ -469,7 +469,7 @@ class ClientPartyMember extends PartyMember {
       ...data,
       FrontendEmote: {
         ...data.FrontendEmote,
-        emoteItemDef: 'None',
+        pickable: 'None',
         emoteSection: -1,
       },
     });

--- a/src/structures/party/PartyMemberMeta.ts
+++ b/src/structures/party/PartyMemberMeta.ts
@@ -25,7 +25,7 @@ class PartyMemberMeta extends Meta<PartyMemberSchema> {
    * The current emote EID
    */
   public get emote(): string | undefined {
-    const emoteAsset: string = this.get('Default:FrontendEmote_j')?.FrontendEmote?.emoteItemDef;
+    const emoteAsset: string = this.get('Default:FrontendEmote_j')?.FrontendEmote?.pickable;
     if (emoteAsset === 'None' || !emoteAsset) return undefined;
     return emoteAsset.match(/(?<=\w*\.)\w*/)?.shift();
   }


### PR DESCRIPTION
This PR addresses a recent update from Epic that modified how party member metadata handles emotes. Specifically, emotes are now referenced using `pickable` instead of `emoteItemDef`. As a result of this change, the .setEmote method broke. 